### PR TITLE
some fixes/workarounds for out use-cases & interchangeable ui components

### DIFF
--- a/packages/ra-core/src/controller/ListController.js
+++ b/packages/ra-core/src/controller/ListController.js
@@ -232,6 +232,7 @@ export class ListController extends Component {
             data,
             ids,
             total,
+            totalAll,
             isLoading,
             translate,
             version,
@@ -277,6 +278,7 @@ export class ListController extends Component {
             showFilter: this.showFilter,
             translate,
             total,
+            totalAll,
             version,
         });
     }
@@ -316,6 +318,7 @@ ListController.propTypes = {
     setSelectedIds: PropTypes.func.isRequired,
     toggleItem: PropTypes.func.isRequired,
     total: PropTypes.number.isRequired,
+    totalAll: PropTypes.number.isRequired,
     translate: PropTypes.func.isRequired,
     version: PropTypes.number,
 };
@@ -362,6 +365,7 @@ function mapStateToProps(state, props) {
         ids: resourceState.list.ids,
         selectedIds: resourceState.list.selectedIds,
         total: resourceState.list.total,
+        totalAll: resourceState.list.totalAll,
         data: resourceState.data,
         isLoading: state.admin.loading > 0,
         filterValues: resourceState.list.params.filter,

--- a/packages/ra-core/src/controller/ListController.js
+++ b/packages/ra-core/src/controller/ListController.js
@@ -82,7 +82,7 @@ export class ListController extends Component {
             return;
         }
 
-        this.updateData();
+        this.updateData(this.props);
         if (Object.keys(this.props.query).length > 0) {
             this.props.changeListParams(this.props.resource, this.props.query);
         }
@@ -98,16 +98,18 @@ export class ListController extends Component {
             nextProps.query.sort !== this.props.query.sort ||
             nextProps.query.order !== this.props.query.order ||
             nextProps.query.page !== this.props.query.page ||
+            nextProps.query.perPage !== this.props.query.perPage ||
             nextProps.query.filter !== this.props.query.filter
         ) {
             this.updateData(
+                nextProps,
                 Object.keys(nextProps.query).length > 0
                     ? nextProps.query
                     : nextProps.params
             );
         }
         if (nextProps.version !== this.props.version) {
-            this.updateData();
+            this.updateData(nextProps);
         }
     }
 
@@ -144,18 +146,17 @@ export class ListController extends Component {
             query.sort = this.props.sort.field;
             query.order = this.props.sort.order;
         }
-        if (!query.perPage) {
-            query.perPage = this.props.perPage;
-        }
+        query.perPage = this.props.perPage;
         if (!query.page) {
             query.page = 1;
         }
         return query;
     }
 
-    updateData(query) {
+    updateData(props, query) {
         const params = query || this.getQuery();
-        const { sort, order, page = 1, perPage, filter } = params;
+        const { perPage } = props;
+        const { sort, order, page = 1, filter } = params;
         const pagination = {
             page: parseInt(page, 10),
             perPage: parseInt(perPage, 10),

--- a/packages/ra-core/src/reducer/admin/resource/list/index.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/index.js
@@ -3,6 +3,7 @@ import ids from './ids';
 import params from './params';
 import selectedIds from './selectedIds';
 import total from './total';
+import totalAll from './totalAll';
 
 export default resource =>
     combineReducers({
@@ -10,4 +11,5 @@ export default resource =>
         params: params(resource),
         selectedIds,
         total: total(resource),
+        totalAll: totalAll(resource),
     });

--- a/packages/ra-core/src/reducer/admin/resource/list/totalAll.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/totalAll.js
@@ -1,0 +1,25 @@
+import {
+    CRUD_GET_ONE_SUCCESS,
+    CRUD_GET_LIST_SUCCESS,
+    CRUD_DELETE_OPTIMISTIC,
+    CRUD_DELETE_MANY_OPTIMISTIC,
+} from '../../../../actions/dataActions';
+
+export default resource => (previousState = 0, { type, payload, meta }) => {
+    if (!meta || meta.resource !== resource) {
+        return previousState;
+    }
+    if (type === CRUD_GET_ONE_SUCCESS) {
+        return previousState == 0 ? 1 : previousState;
+    }
+    if (type === CRUD_GET_LIST_SUCCESS) {
+        return payload.totalAll;
+    }
+    if (type === CRUD_DELETE_OPTIMISTIC) {
+        return previousState - 1;
+    }
+    if (type === CRUD_DELETE_MANY_OPTIMISTIC) {
+        return previousState - payload.ids.length;
+    }
+    return previousState;
+};

--- a/packages/ra-ui-materialui/src/button/CreateButton.js
+++ b/packages/ra-ui-materialui/src/button/CreateButton.js
@@ -35,16 +35,18 @@ const styles = theme => ({
 });
 
 const CreateButton = ({
+    ButtonClass,
     basePath = '',
     className,
     classes = {},
-    translate,
+    icon,
     label = 'ra.action.create',
+    translate,
     ...rest
 }) => (
     <Responsive
         small={
-            <Button
+            <ButtonClass
                 component={Link}
                 variant="fab"
                 color="primary"
@@ -52,30 +54,39 @@ const CreateButton = ({
                 to={`${basePath}/create`}
                 {...rest}
             >
-                <ContentAdd />
-            </Button>
+                {React.cloneElement(icon)}
+            </ButtonClass>
         }
         medium={
-            <Button
+            <ButtonClass
                 component={Link}
                 color="primary"
                 to={`${basePath}/create`}
                 className={classnames(classes.desktopLink, className)}
                 {...rest}
             >
-                <ContentAdd className={classes.iconPaddingStyle} />
+                {React.cloneElement(icon, {
+                    className: classes.iconPaddingStyle,
+                })}
                 {label && translate(label)}
-            </Button>
+            </ButtonClass>
         }
     />
 );
 
 CreateButton.propTypes = {
+    ButtonClass: PropTypes.object.isRequired,
     basePath: PropTypes.string,
     className: PropTypes.string,
     classes: PropTypes.object,
+    icon: PropTypes.element.isRequired,
     label: PropTypes.string,
     translate: PropTypes.func.isRequired,
+};
+
+CreateButton.defaultProps = {
+    ButtonClass: Button,
+    icon: <ContentAdd />,
 };
 
 const enhance = compose(

--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -137,6 +137,7 @@ ReferenceField.propTypes = {
     record: PropTypes.object,
     reference: PropTypes.string.isRequired,
     resource: PropTypes.string,
+    sortBy: PropTypes.string,
     source: PropTypes.string.isRequired,
     translateChoice: PropTypes.func,
     linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])

--- a/packages/ra-ui-materialui/src/input/TextInput.js
+++ b/packages/ra-ui-materialui/src/input/TextInput.js
@@ -46,6 +46,7 @@ export class TextInput extends Component {
             resource,
             source,
             type,
+            textField,
             ...rest
         } = this.props;
         if (typeof meta === 'undefined') {
@@ -55,29 +56,27 @@ export class TextInput extends Component {
         }
         const { touched, error } = meta;
 
-        return (
-            <TextField
-                margin="normal"
-                type={type}
-                label={
-                    <FieldTitle
-                        label={label}
-                        source={source}
-                        resource={resource}
-                        isRequired={isRequired}
-                    />
-                }
-                error={!!(touched && error)}
-                helperText={touched && error}
-                className={className}
-                {...options}
-                {...sanitizeRestProps(rest)}
-                {...input}
-                onBlur={this.handleBlur}
-                onFocus={this.handleFocus}
-                onChange={this.handleChange}
-            />
-        );
+        return React.cloneElement(textField, {
+            margin: 'normal',
+            type,
+            label: (
+                <FieldTitle
+                    label={label}
+                    source={source}
+                    resource={resource}
+                    isRequired={isRequired}
+                />
+            ),
+            error: !!(touched && error),
+            helperText: touched && error,
+            className,
+            ...options,
+            ...sanitizeRestProps(rest),
+            ...input,
+            onBlur: this.handleBlur,
+            onFocus: this.handleFocus,
+            onChange: this.handleChange,
+        });
     }
 }
 
@@ -94,6 +93,7 @@ TextInput.propTypes = {
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,
+    textField: PropTypes.element.isRequired,
     type: PropTypes.string,
 };
 
@@ -102,6 +102,7 @@ TextInput.defaultProps = {
     onChange: () => {},
     onFocus: () => {},
     options: {},
+    textField: <TextField />,
     type: 'text',
 };
 

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -35,9 +35,9 @@ export const DatagridHeaderCell = ({
                 enterDelay={300}
             >
                 <TableSortLabel
-                    active={field.props.source === currentSort.field}
+                    active={(field.props.sortBy || field.props.source) === currentSort.field}
                     direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
-                    data-sort={field.props.source}
+                    data-sort={field.props.sortBy || field.props.source}
                     onClick={updateSort}
                 >
                     <FieldTitle

--- a/packages/ra-ui-materialui/src/list/Filter.js
+++ b/packages/ra-ui-materialui/src/list/Filter.js
@@ -53,6 +53,7 @@ export class Filter extends Component {
             children,
             hideFilter,
             displayedFilters,
+            inActionsToolbar,
             showFilter,
             filterValues,
             setFilters,
@@ -66,6 +67,7 @@ export class Filter extends Component {
                 filters={React.Children.toArray(children)}
                 hideFilter={hideFilter}
                 displayedFilters={displayedFilters}
+                inActionsToolbar={inActionsToolbar}
                 initialValues={filterValues}
                 setFilters={setFilters}
                 {...rest}
@@ -89,6 +91,7 @@ Filter.propTypes = {
     filterButton: PropTypes.element,
     filterValues: PropTypes.object,
     hideFilter: PropTypes.func,
+    inActionsToolbar: PropTypes.bool,
     setFilters: PropTypes.func,
     showFilter: PropTypes.func,
     resource: PropTypes.string.isRequired,

--- a/packages/ra-ui-materialui/src/list/Filter.js
+++ b/packages/ra-ui-materialui/src/list/Filter.js
@@ -53,6 +53,7 @@ export class Filter extends Component {
             children,
             hideFilter,
             displayedFilters,
+            formClasses,
             inActionsToolbar,
             showFilter,
             filterValues,
@@ -62,6 +63,7 @@ export class Filter extends Component {
 
         return (
             <FilterForm
+                classes={formClasses}
                 className={classes.form}
                 resource={resource}
                 filters={React.Children.toArray(children)}
@@ -90,6 +92,7 @@ Filter.propTypes = {
     displayedFilters: PropTypes.object,
     filterButton: PropTypes.element,
     filterValues: PropTypes.object,
+    formClasses: PropTypes.object,
     hideFilter: PropTypes.func,
     inActionsToolbar: PropTypes.bool,
     setFilters: PropTypes.func,

--- a/packages/ra-ui-materialui/src/list/Filter.js
+++ b/packages/ra-ui-materialui/src/list/Filter.js
@@ -25,12 +25,14 @@ export class Filter extends Component {
             showFilter,
             hideFilter,
             displayedFilters,
+            filterButton,
             filterValues,
             ...rest
         } = this.props;
 
         return (
             <FilterButton
+                button={filterButton}
                 className={classes.button}
                 resource={resource}
                 filters={React.Children.toArray(children)}
@@ -84,6 +86,7 @@ Filter.propTypes = {
     context: PropTypes.oneOf(['form', 'button']),
     debounce: PropTypes.number.isRequired,
     displayedFilters: PropTypes.object,
+    filterButton: PropTypes.element,
     filterValues: PropTypes.object,
     hideFilter: PropTypes.func,
     setFilters: PropTypes.func,

--- a/packages/ra-ui-materialui/src/list/FilterButton.js
+++ b/packages/ra-ui-materialui/src/list/FilterButton.js
@@ -68,6 +68,7 @@ export class FilterButton extends Component {
     render() {
         const hiddenFilters = this.getHiddenFilters();
         const {
+            button,
             classes = {},
             className,
             resource,
@@ -82,16 +83,18 @@ export class FilterButton extends Component {
         return (
             hiddenFilters.length > 0 && (
                 <div className={classnames(classes.root, className)} {...rest}>
-                    <Button
-                        ref={node => {
-                            this.button = node;
-                        }}
-                        className="add-filter"
-                        label="ra.action.add_filter"
-                        onClick={this.handleClickButton}
-                    >
-                        <ContentFilter />
-                    </Button>
+                    {React.cloneElement(
+                        button,
+                        {
+                            ref: node => {
+                                this.button = node;
+                            },
+                            className: 'add-filter',
+                            label: 'ra.action.add_filter',
+                            onClick: this.handleClickButton,
+                        },
+                        button.props.children || <ContentFilter />
+                    )}
                     <Menu
                         open={open}
                         anchorEl={anchorEl}
@@ -113,6 +116,7 @@ export class FilterButton extends Component {
 }
 
 FilterButton.propTypes = {
+    button: PropTypes.element.isRequired,
     resource: PropTypes.string.isRequired,
     filters: PropTypes.arrayOf(PropTypes.node).isRequired,
     displayedFilters: PropTypes.object.isRequired,
@@ -121,6 +125,10 @@ FilterButton.propTypes = {
     translate: PropTypes.func.isRequired,
     classes: PropTypes.object,
     className: PropTypes.string,
+};
+
+FilterButton.defaultProps = {
+    button: <Button />,
 };
 
 export default compose(translate, withStyles(styles))(FilterButton);

--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -112,7 +112,8 @@ export class FilterForm extends Component {
                                 data-source={filterElement.props.source}
                                 className={classnames(
                                     'filter-field',
-                                    classes.body
+                                    classes.body,
+                                    filterElement.props.containerClassName
                                 )}
                             >
                                 {filterElement.props.alwaysOn ? (

--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -72,13 +72,20 @@ const sanitizeRestProps = ({
 
 export class FilterForm extends Component {
     getShownFilters() {
-        const { filters, displayedFilters, initialValues } = this.props;
+        const {
+            filters,
+            displayedFilters,
+            inActionsToolbar,
+            initialValues,
+        } = this.props;
 
         return filters.filter(
             filterElement =>
-                filterElement.props.alwaysOn ||
-                displayedFilters[filterElement.props.source] ||
-                typeof initialValues[filterElement.props.source] !== 'undefined'
+                inActionsToolbar === filterElement.props.inActionsToolbar &&
+                (filterElement.props.alwaysOn ||
+                    displayedFilters[filterElement.props.source] ||
+                    typeof initialValues[filterElement.props.source] !==
+                        'undefined')
         );
     }
 
@@ -146,6 +153,7 @@ FilterForm.propTypes = {
     filters: PropTypes.arrayOf(PropTypes.node).isRequired,
     displayedFilters: PropTypes.object.isRequired,
     hideFilter: PropTypes.func.isRequired,
+    inActionsToolbar: PropTypes.bool,
     initialValues: PropTypes.object,
     translate: PropTypes.func.isRequired,
     classes: PropTypes.object,

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -123,6 +123,7 @@ export const ListView = ({
                         refresh,
                         resource,
                         selectedIds,
+                        setFilters,
                         showFilter,
                     }}
                 />

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -43,6 +43,7 @@ const sanitizeRestProps = ({
     data,
     ids,
     total,
+    totalAll,
     isLoading,
     translate,
     version,
@@ -96,12 +97,13 @@ export const ListView = ({
     showFilter,
     title,
     total,
+    totalAll,
     translate,
     version,
     ...rest
 }) => {
     const titleElement = (
-        <TitleClass title={title} defaultTitle={defaultTitle} total={total} />
+        <TitleClass title={title} defaultTitle={defaultTitle} total={totalAll} />
     );
 
     return (
@@ -227,6 +229,7 @@ ListView.propTypes = {
     showFilter: PropTypes.func,
     title: PropTypes.any,
     total: PropTypes.number,
+    totalAll: PropTypes.number,
     translate: PropTypes.func,
     version: PropTypes.number,
 };

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -22,6 +22,7 @@ const styles = {
 };
 
 const sanitizeRestProps = ({
+    TitleClass,
     children,
     classes,
     className,
@@ -63,6 +64,7 @@ const sanitizeRestProps = ({
 }) => rest;
 
 export const ListView = ({
+    TitleClass,
     actions = <DefaultActions />,
     basePath,
     bulkActions = <DefaultBulkActions />,
@@ -98,7 +100,9 @@ export const ListView = ({
     version,
     ...rest
 }) => {
-    const titleElement = <Title title={title} defaultTitle={defaultTitle} />;
+    const titleElement = (
+        <TitleClass title={title} defaultTitle={defaultTitle} total={total} />
+    );
 
     return (
         <div
@@ -274,6 +278,7 @@ const List = props => (
 
 List.propTypes = {
     // the props you can change
+    TitleClass: PropTypes.object.isRequired,
     actions: PropTypes.element,
     bulkActions: PropTypes.oneOfType([PropTypes.element, PropTypes.bool]),
     children: PropTypes.node,
@@ -302,6 +307,7 @@ List.propTypes = {
 };
 
 List.defaultProps = {
+    TitleClass: Title,
     filter: {},
     perPage: 10,
     theme: defaultTheme,

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -129,6 +129,7 @@ export const ListView = ({
                         selectedIds,
                         setFilters,
                         showFilter,
+                        total,
                     }}
                 />
                 {filters &&
@@ -138,6 +139,7 @@ export const ListView = ({
                         hideFilter,
                         resource,
                         setFilters,
+                        total,
                         context: 'form',
                     })}
                 {isLoading || total > 0 ? (


### PR DESCRIPTION
This PR is fixing the `perPage` prop of the List Component, and allows the injection of custom Elements or Element Classes for FilterButton, CreateButton and TextInput. I am not entirely happy with the interface I am providing yet, but it felt like the path of least resistance. We should probably aim for a consistent interface once we have implemented more use-cases.