### PR TITLE
Prevent typeerror when classes is undefined

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -38,7 +38,7 @@ const ShowView = ({
     actions = <DefaultActions />,
     basePath,
     children,
-    classes,
+    classes = {},
     className,
     defaultTitle,
     hasEdit,


### PR DESCRIPTION
I noticed on Sentry there was a TypeError related to calling `card` on an undefined object. I think it's this change.