### PR TITLE
Pass record to actions of show page

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -69,6 +69,7 @@ const ShowView = ({
                     data: record,
                     hasList,
                     hasEdit,
+                    record,
                     resource,
                 }}
             />


### PR DESCRIPTION
#### Feature

🚀 Pass record to the actions component on the details/show page to allow accessing data from it. E.g. required for showing the PWWeb link on mandates show page in [CRM-47](https://hqtrust.atlassian.net/browse/CRM-47):

<img width="1279" alt="pasted_image_27_04_18__16_04" src="https://user-images.githubusercontent.com/3586316/39366612-b67986b8-4a34-11e8-9da1-08f6f724d251.png">
