### PR TITLE
fix default values on ReferenceInputs and ReferenceArrayInputs

### DIFF
--- a/packages/ra-core/src/controller/input/ReferenceArrayInputController.js
+++ b/packages/ra-core/src/controller/input/ReferenceArrayInputController.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import debounce from 'lodash/debounce';
 import compose from 'recompose/compose';
 import { createSelector } from 'reselect';
+import get from 'lodash/get';
 
 import {
     crudGetMany as crudGetManyAction,
@@ -177,13 +178,19 @@ export class ReferenceArrayInputController extends Component {
 
     render() {
         const {
+            attributeName,
+            children,
             input,
-            referenceRecords,
             matchingReferences,
             onChange,
-            children,
+            record,
+            referenceRecords,
             translate,
         } = this.props;
+        const givenRecords = get(record, attributeName);
+        const defaultValue = givenRecords
+            ? givenRecords.map(r => r.id)
+            : undefined;
 
         const dataStatus = getDataStatus({
             input,
@@ -194,6 +201,7 @@ export class ReferenceArrayInputController extends Component {
 
         return children({
             choices: dataStatus.choices,
+            defaultValue,
             error: dataStatus.error,
             isLoading: dataStatus.waiting,
             onChange,
@@ -207,6 +215,7 @@ export class ReferenceArrayInputController extends Component {
 
 ReferenceArrayInputController.propTypes = {
     allowEmpty: PropTypes.bool.isRequired,
+    attributeName: PropTypes.string,
     basePath: PropTypes.string,
     children: PropTypes.func.isRequired,
     className: PropTypes.string,

--- a/packages/ra-core/src/controller/input/ReferenceInputController.js
+++ b/packages/ra-core/src/controller/input/ReferenceInputController.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import debounce from 'lodash/debounce';
 import compose from 'recompose/compose';
 import { createSelector } from 'reselect';
+import get from 'lodash/get';
 
 import { crudGetOne, crudGetMatching } from '../../actions/dataActions';
 import {
@@ -172,13 +173,16 @@ export class ReferenceInputController extends Component {
 
     render() {
         const {
+            children,
             input,
-            referenceRecord,
             matchingReferences,
             onChange,
-            children,
+            record,
+            referenceRecord,
+            source,
             translate,
         } = this.props;
+        const defaultValue = get(record, source);
 
         const dataStatus = getDataStatus({
             input,
@@ -189,6 +193,7 @@ export class ReferenceInputController extends Component {
 
         return children({
             choices: dataStatus.choices,
+            defaultValue,
             error: dataStatus.error,
             isLoading: dataStatus.waiting,
             onChange,

--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.js
@@ -9,11 +9,11 @@ import ReferenceError from './ReferenceError';
 
 const sanitizeRestProps = ({
     alwaysOn,
+    attributeName,
     basePath,
     component,
     crudGetMany,
     crudGetMatching,
-    defaultValue,
     filterToQuery,
     formClassName,
     initializeForm,
@@ -225,6 +225,7 @@ export const ReferenceArrayInput = ({ children, ...props }) => {
 
 ReferenceArrayInput.propTypes = {
     allowEmpty: PropTypes.bool.isRequired,
+    attributeName: PropTypes.string,
     basePath: PropTypes.string,
     children: PropTypes.element.isRequired,
     className: PropTypes.string,

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.js
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.js
@@ -15,7 +15,6 @@ const sanitizeRestProps = ({
     component,
     crudGetMatching,
     crudGetOne,
-    defaultValue,
     filter,
     filterToQuery,
     formClassName,


### PR DESCRIPTION
It looks like the default value displayment of reference and reference array inputs did not work in the current version of react-admin. This PR fixes it which is necessary for [CRM-94](https://hqtrust.atlassian.net/browse/CRM-94).