### PR TITLE
Remove style that restricts input width in forms

### DIFF
--- a/packages/ra-ui-materialui/src/form/FormInput.js
+++ b/packages/ra-ui-materialui/src/form/FormInput.js
@@ -1,17 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { withStyles } from 'material-ui/styles';
 
 import Labeled from '../input/Labeled';
 
 const sanitizeRestProps = ({ basePath, record, resoure, ...rest }) => rest;
 
-const styles = theme => ({
-    input: { width: theme.spacing.unit * 32 },
-});
-
-export const FormInput = ({ classes, input, ...rest }) =>
+export const FormInput = ({ input, ...rest }) =>
     input ? (
         <div
             className={classnames(
@@ -23,23 +18,13 @@ export const FormInput = ({ classes, input, ...rest }) =>
             {input.props.addLabel ? (
                 <Labeled {...input.props} {...sanitizeRestProps(rest)}>
                     {React.cloneElement(input, {
-                        className: classnames(
-                            {
-                                [classes.input]: !input.props.fullWidth,
-                            },
-                            input.props.className
-                        ),
+                        className: input.props.className,
                         ...rest,
                     })}
                 </Labeled>
             ) : (
                 React.cloneElement(input, {
-                    className: classnames(
-                        {
-                            [classes.input]: !input.props.fullWidth,
-                        },
-                        input.props.className
-                    ),
+                    className: input.props.className,
                     ...rest,
                 })
             )}
@@ -48,8 +33,7 @@ export const FormInput = ({ classes, input, ...rest }) =>
 
 FormInput.propTypes = {
     className: PropTypes.string,
-    classes: PropTypes.object,
     input: PropTypes.object,
 };
 
-export default withStyles(styles)(FormInput);
+export default FormInput;


### PR DESCRIPTION
I messed up, and pushed the updated `ra-ui-materialui-build` commit without actually merging the changes into the main library. Here's what I changed. It basically removes an arbitrary restriction on form input width (I remember Tom mentioned he had a problem with it a little while ago, and I did too).

Just to reiterate, these changes are already in the app (with https://github.com/HQTrust/hqtrust-internal-app/pull/82)