### PR TITLE
Include resource names in data action notifications

### DIFF
--- a/packages/ra-core/src/actions/dataActions.js
+++ b/packages/ra-core/src/actions/dataActions.js
@@ -47,6 +47,12 @@ export const crudGetOne = (resource, id, basePath) => ({
             notification: {
                 body: 'ra.notification.item_doesnt_exist',
                 level: 'warning',
+                messageArgs: {
+                    smart_count: 1,
+                    translatables: {
+                        resource: `ra.resources.${resource}`,
+                    },
+                },
             },
             redirectTo: 'list',
             refresh: true,
@@ -71,6 +77,9 @@ export const crudCreate = (resource, data, basePath, redirectTo = 'edit') => ({
                 level: 'info',
                 messageArgs: {
                     smart_count: 1,
+                    translatables: {
+                        resource: `ra.resources.${resource}`,
+                    },
                 },
             },
             redirectTo,
@@ -111,6 +120,9 @@ export const crudUpdate = (
                 level: 'info',
                 messageArgs: {
                     smart_count: 1,
+                    translatables: {
+                        resource: `ra.resources.${resource}`,
+                    },
                 },
             },
             redirectTo,
@@ -151,6 +163,9 @@ export const crudUpdateMany = (
                 level: 'info',
                 messageArgs: {
                     smart_count: ids.length,
+                    translatables: {
+                        resource: `ra.resources.${resource}`,
+                    },
                 },
             },
             basePath,
@@ -191,6 +206,9 @@ export const crudDelete = (
                 level: 'info',
                 messageArgs: {
                     smart_count: 1,
+                    translatables: {
+                        resource: `ra.resources.${resource}`,
+                    },
                 },
             },
             redirectTo,

--- a/packages/ra-core/src/i18n/TranslationProvider.js
+++ b/packages/ra-core/src/i18n/TranslationProvider.js
@@ -43,10 +43,21 @@ const withI18nContext = withContext(
             locale,
             phrases: defaultsDeep({}, messages, defaultMessages),
         });
+        const t = polyglot.t.bind(polyglot);
+        const translate = (key, interpolationOptions = {}) => {
+            const { translatables, ...rest } = interpolationOptions;
+            const options = rest;
+            if (translatables !== undefined) {
+                Object.keys(translatables).forEach((translatableKey) => {
+                    options[translatableKey] = t(translatables[translatableKey], rest);
+                });
+            }
+            return t(key, options);
+        }
 
         return {
             locale,
-            translate: polyglot.t.bind(polyglot),
+            translate,
         };
     }
 );


### PR DESCRIPTION
I am adding resource names to notifications emitted by `dataAction`s in this pr. I had to extend the functionality of the `translate` function a little bit so that we can pass translatable keys into `interpolationOptions` to have them translated too. To provide an example, this is necessary to have e.g. a notification with body "Familie erfolgreich angelegt" rather than "families erfolgreich angelegt"