### PR TITLE
Remove unnecessary styling and wrapping of title

### DIFF
--- a/packages/ra-ui-materialui/src/layout/ViewTitle.js
+++ b/packages/ra-ui-materialui/src/layout/ViewTitle.js
@@ -1,27 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CardContent } from 'material-ui/Card';
 import Typography from 'material-ui/Typography';
-import classnames from 'classnames';
 
-import Responsive from './Responsive';
-import AppBarMobile from './AppBarMobile';
-
-const ViewTitle = ({ className, title, ...rest }) => (
-    <Responsive
-        xsmall={
-            <AppBarMobile
-                className={classnames('title', className)}
-                title={title}
-                {...rest}
-            />
-        }
-        medium={
-            <CardContent className={classnames('title', className)} {...rest}>
-                <Typography variant="headline">{title}</Typography>
-            </CardContent>
-        }
-    />
+const ViewTitle = ({ className, title }) => (
+    <Typography className={className} variant="headline">
+        {title}
+    </Typography>
 );
 
 ViewTitle.propTypes = {


### PR DESCRIPTION
On medium and up it was giving extra unnecessary padding. On small and down it was doing this weird `AppBar` thing that totally clashed with our style.