### PR TITLE
Pass additional props/class styles down and prevent the Card from render if filters aren't provided

### DIFF
--- a/packages/ra-ui-materialui/src/detail/Show.js
+++ b/packages/ra-ui-materialui/src/detail/Show.js
@@ -56,6 +56,7 @@ const ShowView = ({
     >
         <div className={classes.card} style={{ opacity: isLoading ? 0.8 : 1 }}>
             <Header
+                className={classes.header}
                 title={
                     <RecordTitle
                         title={title}
@@ -89,6 +90,7 @@ ShowView.propTypes = {
     basePath: PropTypes.string,
     children: PropTypes.element,
     className: PropTypes.string,
+    classes: PropTypes.object,
     defaultTitle: PropTypes.any,
     hasEdit: PropTypes.bool,
     hasList: PropTypes.bool,

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -152,16 +152,16 @@ export const ListView = ({
                     }}
                 />
             }
-            <Card
-                classes={{
-                    root: classnames(classes.filtersContainer, {
-                        [classes.filtersContainerCollapsed]:
-                            Object.keys(displayedFilters).length === 0,
-                    }),
-                }}
-            >
-                {filters &&
-                    React.cloneElement(filters, {
+            {filters && (
+                <Card
+                    classes={{
+                        root: classnames(classes.filtersContainer, {
+                            [classes.filtersContainerCollapsed]:
+                                Object.keys(displayedFilters).length === 0,
+                        }),
+                    }}
+                >
+                    {React.cloneElement(filters, {
                         displayedFilters,
                         enableSource,
                         enabledSources,
@@ -175,7 +175,8 @@ export const ListView = ({
                         total,
                         context: 'form',
                     })}
-            </Card>
+                </Card>
+            )}
             {isLoading || total > 0 ? (
                 <div key={version}>
                     {children &&
@@ -191,7 +192,9 @@ export const ListView = ({
                             onToggleItem,
                             resource,
                             selectedIds,
+                            setFilters,
                             setSort,
+                            total,
                             version,
                         })}
                     {!isLoading &&


### PR DESCRIPTION
This accomplishes a few things:
1. Pass `total` and `setFilters` props down to the children rendered for the List view
2. Prevents the filter Card from rendering if the filter prop is not passed in
3. Allows styling the Show header through a passed in classes name

This corresponds to the changes made to the frontend app, which moves the TabBar and SearchFields outside of the filter component, and allows for some more separation of concerns and easier styling.