### PR TITLE
unauthenticated layout

### DIFF
--- a/packages/ra-core/src/CoreAdmin.js
+++ b/packages/ra-core/src/CoreAdmin.js
@@ -18,6 +18,7 @@ import CoreAdminRouter from './CoreAdminRouter';
 
 const CoreAdmin = ({
     appLayout,
+    unauthenticatedLayout,
     authProvider,
     children,
     customReducers = {},
@@ -75,9 +76,11 @@ const CoreAdmin = ({
                             exact
                             path="/login"
                             render={props =>
-                                createElement(loginPage, {
-                                    ...props,
-                                    title,
+                                createElement(unauthenticatedLayout, {
+                                    children: createElement(loginPage, {
+                                        ...props,
+                                        title,
+                                    })
                                 })}
                         />
                         <Route
@@ -85,6 +88,7 @@ const CoreAdmin = ({
                             render={props => (
                                 <CoreAdminRouter
                                     appLayout={appLayout}
+                                    unauthenticatedLayout={unauthenticatedLayout}
                                     catchAll={catchAll}
                                     customRoutes={customRoutes}
                                     dashboard={dashboard}
@@ -114,6 +118,7 @@ const componentPropType = PropTypes.oneOfType([
 
 CoreAdmin.propTypes = {
     appLayout: componentPropType,
+    unauthenticatedLayout: componentPropType,
     authProvider: PropTypes.func,
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     catchAll: componentPropType,

--- a/packages/ra-core/src/CoreAdminRouter.js
+++ b/packages/ra-core/src/CoreAdminRouter.js
@@ -89,6 +89,7 @@ export class CoreAdminRouter extends Component {
     render() {
         const {
             appLayout,
+            unauthenticatedLayout,
             catchAll,
             children,
             customRoutes,
@@ -141,10 +142,12 @@ export class CoreAdminRouter extends Component {
                                 exact={route.props.exact}
                                 path={route.props.path}
                                 render={props =>
-                                    this.renderCustomRoutesWithoutLayout(
-                                        route,
-                                        props
-                                    )}
+                                    createElement(unauthenticatedLayout, {
+                                        children: this.renderCustomRoutesWithoutLayout(
+                                            route,
+                                            props
+                                        )
+                                    })}
                             />
                         ))}
                     <Route
@@ -183,6 +186,7 @@ const componentPropType = PropTypes.oneOfType([
 
 CoreAdminRouter.propTypes = {
     appLayout: componentPropType,
+    unauthenticatedLayout: componentPropType,
     authProvider: PropTypes.func,
     catchAll: componentPropType,
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),


### PR DESCRIPTION
As you can see, I decided to just use what was there for using `noLayout` in order to use our sort of blank hqtrust layout. However I called it `unauthenticatedLayout` sice I feel that is like the use-case it serves, giving a frame to views before a user is logged in ..? I also didn't want to introduce more complexety as we are not even using the `noLayout` feature atm...