### PR TITLE
Add script for publishing new builds

### DIFF
--- a/bin/publish-builds.sh
+++ b/bin/publish-builds.sh
@@ -1,0 +1,16 @@
+LAST_COMMIT_MESSAGE="$(git log -1 --pretty=%B)"
+
+function update_build_repo {
+  rm -rf /tmp/$1-build/
+  git clone git@github.com:HQTrust/$1-build.git /tmp/$1-build
+  cp -rf ./packages/$1/* /tmp/$1-build/
+  pushd /tmp/$1-build/
+  git add .
+  git commit -m "$LAST_COMMIT_MESSAGE"
+  git push origin master
+  popd
+}
+
+update_build_repo "ra-core"
+update_build_repo "ra-ui-materialui"
+update_build_repo "react-admin"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
     "private": true,
     "name": "react-admin-lerna",
     "scripts": {
-        "test": "make test"
+        "test": "make test",
+        "publish:hqtrust": "./bin/publish-builds.sh"
     },
     "jest": {
         "setupTestFrameworkScriptFile": "./test-setup.js"


### PR DESCRIPTION
From now on, you can run `yarn publish:hqtrust` to update the build repos where necessary. Last commit message of the main repo is used. I think that is good enough, agree?