### PR TITLE
Simplify error message on login

### DIFF
--- a/packages/ra-core/src/sideEffect/auth.js
+++ b/packages/ra-core/src/sideEffect/auth.js
@@ -45,13 +45,7 @@ export default authProvider => {
                         error: e,
                         meta: { auth: true },
                     });
-                    const errorMessage =
-                        typeof e === 'string'
-                            ? e
-                            : typeof e === 'undefined' || !e.message
-                              ? 'ra.auth.sign_in_error'
-                              : e.message;
-                    yield put(showNotification(errorMessage, 'warning'));
+                    yield put(showNotification('ra.auth.sign_in_error', 'warning'));
                 }
                 break;
             }


### PR DESCRIPTION
I didn't find another way quickly of how to get our own message into the error message on login so I chose to drop the options we are not using...