### PR TITLE
Allow reference many field to dynamically update with a filter change

### DIFF
--- a/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldController.js
@@ -1,6 +1,7 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import isEqual from 'lodash/isEqual'
 
 import { crudGetManyReference as crudGetManyReferenceAction } from '../../actions';
 import {
@@ -70,7 +71,10 @@ export class ReferenceManyFieldController extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if (this.props.record.id !== nextProps.record.id) {
+        if (
+            this.props.record.id !== nextProps.record.id ||
+            !isEqual(this.props.filter, nextProps.filter)
+        ) {
             this.fetchReferences(nextProps);
         }
     }


### PR DESCRIPTION
Previously, the `ReferenceManyFieldController` did not support refetching data when a filter changed. This makes that possible