### PR TITLE
Fix total and totalAll counts for other actions

### DIFF
--- a/packages/ra-core/src/reducer/admin/resource/list/total.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/total.js
@@ -1,4 +1,7 @@
 import {
+    CRUD_CREATE_SUCCESS,
+    CRUD_DELETE_SUCCESS,
+    CRUD_GET_MANY_REFERENCE_SUCCESS,
     CRUD_GET_ONE_SUCCESS,
     CRUD_GET_LIST_SUCCESS,
     CRUD_DELETE_OPTIMISTIC,
@@ -9,17 +12,23 @@ export default resource => (previousState = 0, { type, payload, meta }) => {
     if (!meta || meta.resource !== resource) {
         return previousState;
     }
-    if (type === CRUD_GET_ONE_SUCCESS) {
-        return previousState == 0 ? 1 : previousState;
+
+    switch(type) {
+        case CRUD_GET_ONE_SUCCESS:
+            return previousState == 0 ? 1 : previousState;
+        case CRUD_GET_LIST_SUCCESS:
+            return payload.total || previousState;
+        case CRUD_GET_MANY_REFERENCE_SUCCESS:
+            return payload.total || previousState;
+        case CRUD_CREATE_SUCCESS:
+            return previousState + 1;
+        case CRUD_DELETE_SUCCESS:
+            return previousState - 1;
+        case CRUD_DELETE_OPTIMISTIC:
+            return previousState - 1;
+        case CRUD_DELETE_MANY_OPTIMISTIC:
+            return previousState - payload.ids.length;
+        default:
+            return previousState;
     }
-    if (type === CRUD_GET_LIST_SUCCESS) {
-        return payload.total;
-    }
-    if (type === CRUD_DELETE_OPTIMISTIC) {
-        return previousState - 1;
-    }
-    if (type === CRUD_DELETE_MANY_OPTIMISTIC) {
-        return previousState - payload.ids.length;
-    }
-    return previousState;
 };

--- a/packages/ra-core/src/reducer/admin/resource/list/totalAll.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/totalAll.js
@@ -1,4 +1,7 @@
 import {
+    CRUD_CREATE_SUCCESS,
+    CRUD_DELETE_SUCCESS,
+    CRUD_GET_MANY_REFERENCE_SUCCESS,
     CRUD_GET_ONE_SUCCESS,
     CRUD_GET_LIST_SUCCESS,
     CRUD_DELETE_OPTIMISTIC,
@@ -9,17 +12,23 @@ export default resource => (previousState = 0, { type, payload, meta }) => {
     if (!meta || meta.resource !== resource) {
         return previousState;
     }
-    if (type === CRUD_GET_ONE_SUCCESS) {
-        return previousState == 0 ? 1 : previousState;
+
+    switch(type) {
+        case CRUD_GET_ONE_SUCCESS:
+            return previousState == 0 ? 1 : previousState;
+        case CRUD_GET_LIST_SUCCESS:
+            return payload.totalAll || previousState;
+        case CRUD_GET_MANY_REFERENCE_SUCCESS:
+            return payload.totalAll || previousState;
+        case CRUD_CREATE_SUCCESS:
+            return previousState + 1;
+        case CRUD_DELETE_SUCCESS:
+            return previousState - 1;
+        case CRUD_DELETE_OPTIMISTIC:
+            return previousState - 1;
+        case CRUD_DELETE_MANY_OPTIMISTIC:
+            return previousState - payload.ids.length;
+        default:
+            return previousState;
     }
-    if (type === CRUD_GET_LIST_SUCCESS) {
-        return payload.totalAll;
-    }
-    if (type === CRUD_DELETE_OPTIMISTIC) {
-        return previousState - 1;
-    }
-    if (type === CRUD_DELETE_MANY_OPTIMISTIC) {
-        return previousState - payload.ids.length;
-    }
-    return previousState;
 };


### PR DESCRIPTION
Writing end to end testing is exposing some bugs, and this is part of the fix for it. (Basically I switched up infinite scrolling to use the `total` count to check if we were at the end, but that meant fixing the `total` reducer to track during reference many, as well as update during deletes and creates).