### PR TITLE
Update resource reducer to be able to handle array resource types.

### DIFF
--- a/packages/ra-core/src/reducer/admin/resource/index.js
+++ b/packages/ra-core/src/reducer/admin/resource/index.js
@@ -1,7 +1,13 @@
+import get from 'lodash/get'
+
 import { REGISTER_RESOURCE, UNREGISTER_RESOURCE } from '../../../actions';
 
 import data from './data';
 import list from './list';
+
+export const metaMatchesResource = (meta, resource) => {
+  return get(meta, 'resource[1].name', get(meta, 'resource')) === resource
+}
 
 const initialState = {};
 export default (
@@ -42,7 +48,7 @@ export default (
         (acc, resource) => ({
             ...acc,
             [resource]:
-                action.meta.resource === resource
+                metaMatchesResource(action.meta, resource)
                     ? {
                           props: previousState[resource].props,
                           data: dataReducer(resource)(


### PR DESCRIPTION
Update data reducer to use the request payload as default values on a successful create.

This PR was created to support the work I was doing when refactoring the `InfiniteReferenceManyField` controller, but since I think it is a good idea to have these changes in anyways, I decided to make the PR immediately.