### PR TITLE
Refactor all resource reducers to use metaMatchesResource

### DIFF
--- a/packages/ra-core/src/reducer/admin/resource/list/ids.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.js
@@ -10,6 +10,7 @@ import {
     CRUD_UPDATE_SUCCESS,
     CRUD_DELETE_SUCCESS,
 } from '../../../../actions/dataActions';
+import { metaMatchesResource } from '../index'
 
 import getFetchedAt from '../../../../util/getFetchedAt';
 
@@ -34,7 +35,7 @@ export default resource => (
     previousState = [],
     { type, payload, requestPayload, meta }
 ) => {
-    if (!meta || meta.resource !== resource) {
+    if (!metaMatchesResource(meta, resource)) {
         return previousState;
     }
     switch (type) {

--- a/packages/ra-core/src/reducer/admin/resource/list/params.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/params.js
@@ -1,4 +1,5 @@
 import { CRUD_CHANGE_LIST_PARAMS } from '../../../../actions/listActions';
+import { metaMatchesResource } from '../index'
 
 const defaultState = {
     sort: null,
@@ -12,7 +13,7 @@ export default resource => (
     previousState = defaultState,
     { type, payload, meta }
 ) => {
-    if (!meta || meta.resource !== resource) {
+    if (!metaMatchesResource(meta, resource)) {
         return previousState;
     }
     switch (type) {

--- a/packages/ra-core/src/reducer/admin/resource/list/total.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/total.js
@@ -7,10 +7,11 @@ import {
     CRUD_DELETE_OPTIMISTIC,
     CRUD_DELETE_MANY_OPTIMISTIC,
 } from '../../../../actions/dataActions';
+import { metaMatchesResource } from '../index'
 import isNumber from 'lodash/isNumber'
 
 export default resource => (previousState = 0, { type, payload, meta }) => {
-    if (!meta || meta.resource !== resource) {
+    if (!metaMatchesResource(meta, resource)) {
         return previousState;
     }
 

--- a/packages/ra-core/src/reducer/admin/resource/list/totalAll.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/totalAll.js
@@ -7,10 +7,11 @@ import {
     CRUD_DELETE_OPTIMISTIC,
     CRUD_DELETE_MANY_OPTIMISTIC,
 } from '../../../../actions/dataActions';
+import { metaMatchesResource } from '../index'
 import isNumber from 'lodash/isNumber'
 
 export default resource => (previousState = 0, { type, payload, meta }) => {
-    if (!meta || meta.resource !== resource) {
+    if (!metaMatchesResource(meta, resource)) {
         return previousState;
     }
 


### PR DESCRIPTION
I should have done this with the first branch, but this now uses `metaMatchesResource` (which matches our custom nested resource identifier) for all resource reducers. This specifically is necessary to update total and totalAll when a resource is deleted.