### PR TITLE
CRM-302: fix type error

### DIFF
--- a/packages/ra-core/src/util/removeKey.js
+++ b/packages/ra-core/src/util/removeKey.js
@@ -1,11 +1,16 @@
-const removeKey = (target, path) =>
-    Object.keys(target).reduce((acc, key) => {
+const removeKey = (target, path) => {
+    if (!target) {
+        return target
+    }
+
+    return Object.keys(target).reduce((acc, key) => {
         if (!key.startsWith(path)) {
             return Object.assign({}, acc, { [key]: target[key] });
         }
 
         return acc;
     }, {});
+}
 
 const deepRemoveKey = (target, path) => {
     const paths = path.split('.');
@@ -16,6 +21,10 @@ const deepRemoveKey = (target, path) => {
 
     const deepKey = paths[0];
     const deep = deepRemoveKey(target[deepKey], paths.slice(1).join('.'));
+
+    if (!deep) {
+        return target
+    }
 
     if (Object.keys(deep).length === 0) {
         return removeKey(target, deepKey);


### PR DESCRIPTION
This PR fixes the bug filed as [CRM-302](https://hqtrust.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=CRM&modal=detail&selectedIssue=CRM-302). The bug occurred because initial filters set in the CRM are not known by the `ListController` in `react-admin`. When deselecting one of these initial filters, it leads to `react-admin` trying to remove a filter that is not in its current filters object. This happens roughly here: https://github.com/HQTrust/react-admin/blob/hqtrust/packages/ra-core/src/controller/ListController.js#L282
Adding checks for the presence of the key in question fixes the error.

I will also create a PR on the CRM to bump the build versions of `react-admin` after approval of this PR.