### PR TITLE
Add a reducer to keep track of filtered resource (total-)counts

### DIFF
--- a/packages/ra-core/src/reducer/admin/references/oneToMany.js
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.js
@@ -1,4 +1,5 @@
 import { CRUD_GET_MANY_REFERENCE_SUCCESS } from '../../../actions/dataActions';
+import { parse } from 'query-string';
 
 const initialState = {};
 
@@ -92,3 +93,23 @@ export const nameRelatedTo = (reference, id, resource, target, filter = {}) => {
         .map(key => `${key}=${JSON.stringify(filter[key])}`)
         .join('&')}`;
 };
+
+export const parseNameRelatedTo = (relatedTo) => {
+  const resourceAndRest = meta.relatedTo.split(/_(.*)/, 2)
+  const resource = resourceAndRest[0]
+  const referenceAndRest = resourceAndRest[1].split(/@(.*)/, 2)
+  const reference = referenceAndRest[0]
+  const targetAndRest = referenceAndRest[1].split(/_(.*)/, 2)
+  const target = targetAndRest[0]
+  const idAndFilter = targetAndRest[1].split(/\?(.*)/, 2)
+  const recordId = idAndFilter[0]
+  const filter = parse(idAndFilter[1])
+
+  return {
+    reference,
+    id,
+    resource,
+    target,
+    filter
+  }
+}

--- a/packages/ra-core/src/reducer/admin/resource/list/index.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/index.js
@@ -4,6 +4,7 @@ import params from './params';
 import selectedIds from './selectedIds';
 import total from './total';
 import totalAll from './totalAll';
+import relatedToCounts from './relatedToCounts';
 
 export default resource =>
     combineReducers({
@@ -12,4 +13,5 @@ export default resource =>
         selectedIds,
         total: total(resource),
         totalAll: totalAll(resource),
+        relatedToCounts: relatedToCounts(resource),
     });

--- a/packages/ra-core/src/reducer/admin/resource/list/relatedToCounts.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/relatedToCounts.js
@@ -1,0 +1,49 @@
+import _ from 'lodash'
+
+import {
+    CRUD_CREATE_SUCCESS,
+    CRUD_DELETE_SUCCESS,
+    CRUD_GET_MANY_REFERENCE_SUCCESS,
+    CRUD_GET_ONE_SUCCESS,
+    CRUD_GET_LIST_SUCCESS,
+    CRUD_DELETE_OPTIMISTIC,
+    CRUD_DELETE_MANY_OPTIMISTIC,
+} from '../../../../actions/dataActions';
+import { metaMatchesResource } from '../index'
+import { nameRelatedTo, parseNameRelatedTo } from '../../references/oneToMany.js'
+
+export default resource => (previousState = {}, { type, payload, meta }) => {
+    if (!metaMatchesResource(meta, resource)) {
+        return previousState;
+    }
+
+  if (type !== CRUD_GET_LIST_SUCCESS && type !== CRUD_GET_MANY_REFERENCE_SUCCESS) {
+    return previousState;
+  }
+
+  const {
+    reference,
+    id,
+    resource: relatedResource,
+    target,
+    filter
+  } = parseNameRelatedTo(meta.relatedTo)
+  const { pagination, sort, ...relevantFilter } = filter
+  const filterSortedByKey = _(relevantFilter).toPairs().sortBy(0).fromPairs().value()
+
+  const relatedTo = nameRelatedTo(
+    reference,
+    id,
+    relatedResource,
+    target,
+    filterSortedByKey
+  )
+
+  switch(type) {
+        case CRUD_GET_LIST_SUCCESS:
+        case CRUD_GET_MANY_REFERENCE_SUCCESS:
+            return _.isNumber(payload.total) ? { ...previousState, [relatedTo]: payload.total } : previousState;
+        default:
+            return previousState;
+    }
+};


### PR DESCRIPTION
This PR adds a (nested) reducer to the `admin.resource.list` namespace that keeps track of the `total` count of resource on a per filtered basis. Previously, only `totalAll` (which is the total amount of unfiltered resources) as well as *one* `total` could be read reliably. The issue around this so to say unscoped `total` counts arose when we started having differently filtered lists of the same resource on one page.