### PR TITLE
More robust pre-condition checks

### DIFF
--- a/packages/ra-core/src/reducer/admin/references/oneToMany.js
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.js
@@ -95,7 +95,7 @@ export const nameRelatedTo = (reference, id, resource, target, filter = {}) => {
 };
 
 export const parseNameRelatedTo = (relatedTo) => {
-  const resourceAndRest = meta.relatedTo.split(/_(.*)/, 2)
+  const resourceAndRest = relatedTo.split(/_(.*)/, 2)
   const resource = resourceAndRest[0]
   const referenceAndRest = resourceAndRest[1].split(/@(.*)/, 2)
   const reference = referenceAndRest[0]
@@ -107,7 +107,7 @@ export const parseNameRelatedTo = (relatedTo) => {
 
   return {
     reference,
-    id,
+    recordId,
     resource,
     target,
     filter

--- a/packages/ra-core/src/reducer/admin/resource/list/relatedToCounts.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/relatedToCounts.js
@@ -13,11 +13,12 @@ import { metaMatchesResource } from '../index'
 import { nameRelatedTo, parseNameRelatedTo } from '../../references/oneToMany.js'
 
 export default resource => (previousState = {}, { type, payload, meta }) => {
-    if (!metaMatchesResource(meta, resource)) {
-        return previousState;
-    }
-
-  if (type !== CRUD_GET_LIST_SUCCESS && type !== CRUD_GET_MANY_REFERENCE_SUCCESS) {
+  if (
+    meta === undefined ||
+    meta.relatedTo === undefined ||
+    !metaMatchesResource(meta, resource) ||
+    (type !== CRUD_GET_LIST_SUCCESS && type !== CRUD_GET_MANY_REFERENCE_SUCCESS)
+  ) {
     return previousState;
   }
 
@@ -40,10 +41,10 @@ export default resource => (previousState = {}, { type, payload, meta }) => {
   )
 
   switch(type) {
-        case CRUD_GET_LIST_SUCCESS:
-        case CRUD_GET_MANY_REFERENCE_SUCCESS:
-            return _.isNumber(payload.total) ? { ...previousState, [relatedTo]: payload.total } : previousState;
-        default:
-            return previousState;
-    }
+    case CRUD_GET_LIST_SUCCESS:
+    case CRUD_GET_MANY_REFERENCE_SUCCESS:
+      return _.isNumber(payload.total) ? { ...previousState, [relatedTo]: payload.total } : previousState;
+    default:
+      return previousState;
+  }
 };


### PR DESCRIPTION
It seems like in rare cases there were some redux actions getting to the reducer that had no `meta` or `meta.relatedTo` set which caused an error in `parseNameRelatedTo`.