### PR TITLE
Added support for composite field in FilterForm

### DIFF
--- a/packages/ra-ui-materialui/src/list/FilterForm.js
+++ b/packages/ra-ui-materialui/src/list/FilterForm.js
@@ -94,12 +94,18 @@ export class FilterForm extends Component {
     getShownFilters() {
         const { filters, displayedFilters, inActionsToolbar } = this.props;
 
-        return filters.filter(
+        let result = filters.filter(
             filterElement =>
                 inActionsToolbar === filterElement.props.inActionsToolbar &&
                 (filterElement.props.alwaysOn ||
                     displayedFilters[filterElement.props.source])
         );
+
+        // unwrap composite inputs -> will show their multiple children in the grid next to other filters
+        result = result.map( filter => filter.props.compositeInput ? React.Children.toArray(filter.props.children) : filter );
+        result = _.flatten(result);
+
+        return result;
     }
 
     handleHide = event =>


### PR DESCRIPTION
- allows rendering multiple filter components per one source field
- implemented to support 🚀 [CRM-524](https://hqtrust.atlassian.net/browse/CRM-524): Add score for data integrity to mandates and contacts
- [#578](https://github.com/HQTrust/hqtrust-internal-app/pull/578) is dependent on this PR